### PR TITLE
Added command line argument for overriding default video device wait time

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ sudo ./setup.sh
 * `-v `     Display verbose output
 * `-g # `   Use specific Entertainment area group number (#)
 * `-s `     Enable latency optimization for single light source centered behind display
+* `-w #`    Sets the video device wait time to the specified value, in seconds. Defaults to 0.75.
 
 **Configurable values within the script:** (Advanced users only)
 
@@ -158,7 +159,7 @@ sudo ./setup.sh
 
 * "Import Error" - Ensure you have all the dependencies installed. Run through the manual dependency install instructions above.
 * No video input // lights are all dim gray - Run `python3 ./videotest.py` to see if your device (via OpenCV) can properly read the video input.
-* w, h, or rgbframe not defined - Increase the waiting time from 0.75 seconds - Line 330 {time.sleep(.75)} *This is a known bug (race condition).
+* w, h, or rgbframe not defined - Increase the waiting time from the default 0.75 seconds by passing the `-w` argument *This is a known bug (race condition).
 * python3-opencv installation fails - Compile from source - [Follow this guide.](https://pimylifeup.com/raspberry-pi-opencv/)
 * Sanity check: The output of the command `ls -ltrh /dev/video*` should provide a list of results that includes /dev/video0 when the OS properly detects the video capture card.
 * Many questions are answered on our Reddit release thread [here.](https://www.reddit.com/r/Hue/comments/i1ngqt/release_harmonize_project_sync_hue_lights_with/) New issues should be raised on Github.

--- a/harmonize.py
+++ b/harmonize.py
@@ -57,6 +57,7 @@ parser.add_argument("-v","--verbose", dest="verbose", action="store_true")
 parser.add_argument("-g","--groupid", dest="groupid")
 parser.add_argument("-b","--bridgeid", dest="bridgeid")
 parser.add_argument("-s","--single_light", dest="single_light", action="store_true")
+parser.add_argument("-w","--video_wait_time", dest="video_wait_time", type=float, default=.75)
 commandlineargs = parser.parse_args()
 
 is_single_light = False
@@ -414,7 +415,7 @@ try:
             t = threading.Thread(target=cv2input_to_buffer)
             t.start()
             threads.append(t)
-            time.sleep(.75)
+            time.sleep(commandlineargs.video_wait_time)
             if (commandlineargs.single_light is True) and (len(lights_dict)==1):
                 is_single_light = True
                 print("Enabled optimization for single light source") # averager thread is not utilized


### PR DESCRIPTION
Added command line argument (`-w`/`--video_wait_time`) for overriding the default video device wait time of 0.75 seconds.

The motivation for adding this is to better automate deployment of the project on lower powered devices. With the default of 0.75 seconds, I often see race condition errors involving `w`, `h` and `rgbframe` on lower powered devices. As per the troubleshooting guide, upping this to a larger wait time avoids the race condition. This CLI argument allows for changing the wait time without having to modify the script directly.