### PR TITLE
Added command line argument for using a file/stream URL instead of video device for capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,13 @@ sudo ./setup.sh
 
 **Command line arguments:**
 
-* `-v `     Display verbose output
-* `-g # `   Use specific Entertainment area group number (#)
-* `-b <id>` Use specified bridge ID
-* `-i <ip>` Use specified bridge IP address
-* `-s `     Enable latency optimization for single light source centered behind display
-* `-w #`    Sets the video device wait time to the specified value, in seconds. Defaults to 0.75.
+* `-v `             Display verbose output
+* `-g # `           Use specific Entertainment area group number (#)
+* `-b <id>`         Use specified bridge ID
+* `-i <ip>`         Use specified bridge IP address
+* `-s `             Enable latency optimization for single light source centered behind display
+* `-w #`            Sets the video device wait time to the specified value, in seconds. Defaults to 0.75.
+* `-f <file/url>`   Use the specified file or URL video stream instead of a video device.
 
 **Configurable values within the script:** (Advanced users only)
 

--- a/videotest.py
+++ b/videotest.py
@@ -1,11 +1,20 @@
 #!/usr/bin/python3
 
 import cv2             # Script Last Updated - Release 1.1.2
+import argparse
 
 print("Press ESC to exit.")
 
+parser = argparse.ArgumentParser()
+parser.add_argument("-f","--stream_filename", dest="stream_filename")
+commandlineargs = parser.parse_args()
+
 cv2.namedWindow("preview")
-vc = cv2.VideoCapture(0)
+
+if commandlineargs.stream_filename is None:
+    vc = cv2.VideoCapture(0)
+else:
+    vc = cv2.VideoCapture(commandlineargs.stream_filename)
 
 if vc.isOpened(): # try to get the first frame
     rval, frame = vc.read()


### PR DESCRIPTION
Added a command line argument (`-f`/`--stream_filename`) for using a specified file/URL instead of directly using a video device for capture. This allows for using a video stream URL or other video file as the CV2 capture source.

The motivation for this is change is primarily to enable Harmonize to use a webcam stream URL. This makes it possible to use in conjunction with something like [RPi_Cam_Web_Interface](https://github.com/silvanmelchior/RPi_Cam_Web_Interface), another excellent project that creates a webcam server using the Raspberry Pi CSI Camera interface and allows for tweaking many camera and video settings. This can make it easier to get the correct capture area/exposure/white balance.

Also of note, by experimenting with tweaking the output video resolution/framerate in this setup, I have been able to run Harmonize on lower powered Raspberry Pis. Good performance is achievable on the 3B with minimal tweaking, but I have also been able to run it on as low as a Raspberry Pi Zero (albeit by lowering the video framerate to ~10 FPS in the case of the Zero).